### PR TITLE
feat: add MariaDB LLM API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ dependencies = [
     "pypdf (>=5.9.0,<6.0.0)",
     "chroma (>=0.2.0,<0.3.0)",
     "sqlalchemy (>=2.0.42,<3.0.0)",
-    "sqlite4 (>=0.1.1,<0.2.0)",
+    "pymysql (>=1.1.0,<2.0.0)",
+    "fastapi (>=0.115.5,<1.0.0)",
+    "uvicorn (>=0.32.0,<1.0.0)",
     "langchain-experimental (>=0.3.4,<0.4.0)",
     "tabulate (>=0.9.0,<0.10.0)"
 ]

--- a/src/first_gen_ai/mariadb_api.py
+++ b/src/first_gen_ai/mariadb_api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dotenv import load_dotenv, find_dotenv
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from langchain_openai import ChatOpenAI
+from langchain_community.utilities import SQLDatabase
+from langchain.chains import create_sql_query_chain
+from functools import lru_cache
+from typing import Any
+import os
+
+load_dotenv(find_dotenv())
+
+
+class QueryRequest(BaseModel):
+    """Schema for incoming natural language questions."""
+
+    question: str
+
+
+def _build_connection_uri() -> str:
+    """Construct a SQLAlchemy connection string for MariaDB.
+
+    The credentials are loaded from environment variables to avoid checking
+    secrets into source control.
+    """
+
+    host = os.getenv("MARIADB_HOST", "localhost")
+    port = os.getenv("MARIADB_PORT", "3306")
+    user = os.getenv("MARIADB_USER")
+    password = os.getenv("MARIADB_PASSWORD")
+    database = os.getenv("MARIADB_DATABASE")
+    return f"mariadb+pymysql://{user}:{password}@{host}:{port}/{database}"
+
+
+@lru_cache
+def _get_db_and_chain() -> tuple[SQLDatabase, Any]:
+    """Create and cache the database and query chain."""
+
+    db = SQLDatabase.from_uri(_build_connection_uri())
+    llm = ChatOpenAI()
+    chain = create_sql_query_chain(llm, db)
+    return db, chain
+
+
+def run_query(question: str) -> str:
+    """Use an LLM to translate a natural language question to SQL and execute it."""
+
+    db, chain = _get_db_and_chain()
+    sql = chain.invoke({"question": question})
+    return db.run(sql)
+
+
+app = FastAPI()
+
+
+@app.post("/query")
+def query_db(request: QueryRequest) -> dict[str, str]:
+    """Endpoint consumed by the React UI to query the database via LLM."""
+
+    try:
+        result = run_query(request.question)
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"result": result}


### PR DESCRIPTION
## Summary
- add FastAPI service that uses LangChain and MariaDB to answer natural language questions
- replace sqlite dependency with pymysql and add web server deps
- cache database connection and LLM chain to avoid reinitialization per request

## Testing
- `python -m py_compile src/first_gen_ai/mariadb_api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d3c43380832b9f69a2c7d3c242ce