### PR TITLE
feat: add MariaDB LLM API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ repos/*
 *.tar
 *.bak
 
+# Node
+node_modules/
+
 # Ignore backups and temp
 *.bak
 *.tmp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ dependencies = [
     "pypdf (>=5.9.0,<6.0.0)",
     "chroma (>=0.2.0,<0.3.0)",
     "sqlalchemy (>=2.0.42,<3.0.0)",
-    "sqlite4 (>=0.1.1,<0.2.0)",
+    "pymysql (>=1.1.0,<2.0.0)",
+    "fastapi (>=0.115.5,<1.0.0)",
+    "uvicorn (>=0.32.0,<1.0.0)",
     "langchain-experimental (>=0.3.4,<0.4.0)",
     "tabulate (>=0.9.0,<0.10.0)"
 ]

--- a/react-app/index.html
+++ b/react-app/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MariaDB Query UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>
+

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mariadb-query-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.1.0"
+  }
+}
+

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+export default function App() {
+  const [question, setQuestion] = useState('');
+  const [result, setResult] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const ask = async () => {
+    setLoading(true);
+    setResult('');
+    try {
+      const response = await fetch('/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question }),
+      });
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+      const data = await response.json();
+      setResult(data.result);
+    } catch (err) {
+      setResult(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>MariaDB Query UI</h1>
+      <textarea
+        rows="4"
+        cols="50"
+        value={question}
+        onChange={(e) => setQuestion(e.target.value)}
+        placeholder="Ask a question about the database"
+      />
+      <div>
+        <button onClick={ask} disabled={loading} style={{ marginTop: '0.5rem' }}>
+          {loading ? 'Running...' : 'Submit'}
+        </button>
+      </div>
+      <pre style={{ background: '#f4f4f4', padding: '0.5rem', marginTop: '1rem' }}>
+        {result}
+      </pre>
+    </div>
+  );
+}
+

--- a/react-app/src/main.jsx
+++ b/react-app/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+

--- a/react-app/vite.config.js
+++ b/react-app/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Proxy API requests during development to the FastAPI backend.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/query': 'http://localhost:8000',
+    },
+  },
+});
+

--- a/src/first_gen_ai/mariadb_api.py
+++ b/src/first_gen_ai/mariadb_api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dotenv import load_dotenv, find_dotenv
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from langchain_openai import ChatOpenAI
+from langchain_community.utilities import SQLDatabase
+from langchain.chains import create_sql_query_chain
+from functools import lru_cache
+from typing import Any
+import os
+
+load_dotenv(find_dotenv())
+
+
+class QueryRequest(BaseModel):
+    """Schema for incoming natural language questions."""
+
+    question: str
+
+
+def _build_connection_uri() -> str:
+    """Construct a SQLAlchemy connection string for MariaDB.
+
+    The credentials are loaded from environment variables to avoid checking
+    secrets into source control.
+    """
+
+    host = os.getenv("MARIADB_HOST", "localhost")
+    port = os.getenv("MARIADB_PORT", "3306")
+    user = os.getenv("MARIADB_USER")
+    password = os.getenv("MARIADB_PASSWORD")
+    database = os.getenv("MARIADB_DATABASE")
+    return f"mariadb+pymysql://{user}:{password}@{host}:{port}/{database}"
+
+
+@lru_cache
+def _get_db_and_chain() -> tuple[SQLDatabase, Any]:
+    """Create and cache the database and query chain."""
+
+    db = SQLDatabase.from_uri(_build_connection_uri())
+    llm = ChatOpenAI()
+    chain = create_sql_query_chain(llm, db)
+    return db, chain
+
+
+def run_query(question: str) -> str:
+    """Use an LLM to translate a natural language question to SQL and execute it."""
+
+    db, chain = _get_db_and_chain()
+    sql = chain.invoke({"question": question})
+    return db.run(sql)
+
+
+app = FastAPI()
+
+
+@app.post("/query")
+def query_db(request: QueryRequest) -> dict[str, str]:
+    """Endpoint consumed by the React UI to query the database via LLM."""
+
+    try:
+        result = run_query(request.question)
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"result": result}


### PR DESCRIPTION
## Summary
- add FastAPI service that uses LangChain and MariaDB to answer natural language questions
- replace sqlite dependency with pymysql and add web server deps
- cache database connection and LLM chain to avoid reinitialization per request
- add React UI to submit questions and display results

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm test`
- `python -m py_compile src/first_gen_ai/mariadb_api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d3c43380832b9f69a2c7d3c242ce